### PR TITLE
Exclude log folder so pip builds successfully

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+0.4 (Unreleased)
+================
+
+- Exclude log folder so pip builds successfully [#16]
+
 0.3 (2024-10-26)
 ================
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,9 @@ docs = [
 "Bug Reports" = "https://github.com/bbtufty/nxbrew-dl/issues"
 "Source" = "https://github.com/bbtufty/nxbrew-dl"
 
+[tool.setuptools.packages.find]
+exclude = ["log/*"]
+
 [build-system]
 requires = [
     "setuptools>=43.0.0",


### PR DESCRIPTION
- Exclude log in pyproject.toml folder so pip builds successfully
