### PR TITLE
Change how the progress bar is updated

### DIFF
--- a/nxbrew_dl/gui/gui_nxbrew_dl.py
+++ b/nxbrew_dl/gui/gui_nxbrew_dl.py
@@ -233,7 +233,6 @@ class MainWindow(QMainWindow):
             )
             return False
 
-
     def update_display(self, text):
         """When using the search bar, show/hide rows
 
@@ -247,6 +246,9 @@ class MainWindow(QMainWindow):
                 self.game_table.showRow(r)
             else:
                 self.game_table.hideRow(r)
+
+    def update_progressbar_value(self, value):
+        self.nxbrew_worker.progress_bar.setValue(value)
 
     def load_table(self):
         """Load the game table, disable things until we're done"""
@@ -450,6 +452,7 @@ class MainWindow(QMainWindow):
 
         self.nxbrew_worker.moveToThread(self.nxbrew_thread)
         self.nxbrew_thread.started.connect(self.nxbrew_worker.run)
+        self.nxbrew_worker.update_progressBar.connect(self.update_progressbar_value)
 
         # Delete the thread once we're done
         self.nxbrew_worker.finished.connect(self.nxbrew_thread.quit)
@@ -527,6 +530,7 @@ class NXBrewWorker(QObject):
     """Handles running NXBrew so GUI doesn't hang"""
 
     finished = Signal()
+    update_progressBar = Signal(int)
 
     def __init__(
         self,
@@ -584,6 +588,7 @@ class NXBrewWorker(QObject):
                 user_config=self.user_config,
                 user_cache=self.user_cache,
                 logger=self.logger,
+                update_progressBar=self.update_progressBar,
             )
             nx.run()
         except (Exception, MYJDException):

--- a/nxbrew_dl/nxbrew_dl/nxbrew.py
+++ b/nxbrew_dl/nxbrew_dl/nxbrew.py
@@ -61,6 +61,7 @@ class NXBrew:
         to_download,
         progress_bar=None,
         progress_bar_label=None,
+        update_progressBar=None,
         general_config=None,
         regex_config=None,
         user_config=None,
@@ -156,6 +157,7 @@ class NXBrew:
         self.to_download = to_download
         self.progress_bar = progress_bar
         self.progress_bar_label = progress_bar_label
+        self.update_progressBar = update_progressBar
 
         self.dry_run = self.user_config.get("dry_run", False)
 
@@ -166,7 +168,7 @@ class NXBrew:
 
         if self.progress_bar is not None:
             # Reset progress bar to 0
-            self.progress_bar.setValue(0)
+            self.update_progressBar.emit(0)
 
         self.logger.info("")
         self.logger.info(f"=" * 80)
@@ -195,7 +197,7 @@ class NXBrew:
 
             if self.progress_bar is not None:
                 # Reset progress bar to 0
-                self.progress_bar.setValue(progress_val)
+                self.update_progressBar.emit(progress_val)
 
         # Clean up
         self.logger.info("Performing final cache/disk clean up")


### PR DESCRIPTION
Changes how the progress bar is updated to use QT Signals. The current implementation causes a crash if you download more than one title at a time due to threading.